### PR TITLE
Present alerts from main thread.

### DIFF
--- a/BiometricsAutomationDemo/ViewController.swift
+++ b/BiometricsAutomationDemo/ViewController.swift
@@ -21,7 +21,9 @@ class ViewController: UIViewController {
                                reply: { success, _ in
                                 let title = success ? "Authenticated successfully!" : "Authentication failed."
                                 let controller = UIAlertController(title: title, message: nil, preferredStyle: .alert)
-                                self.present(controller, animated: true)
+                                DispatchQueue.main.async() {
+                                    self.present(controller, animated: true)
+                                }
                                 
         })
     }


### PR DESCRIPTION
This prevents crashing the app when trying to display an alert from a background thread.